### PR TITLE
prevent_lxml_internal_error

### DIFF
--- a/src/preparation/wp/parsers.py
+++ b/src/preparation/wp/parsers.py
@@ -4,4 +4,4 @@ import lxml.etree
 class DefaultXmlParser:
     @classmethod
     def parse(cls, content):
-        return lxml.etree.fromstring(content)
+        return lxml.etree.fromstring(content, parser=lxml.etree.XMLParser(huge_tree=True))


### PR DESCRIPTION
Prevent XMLSyntaxError: internal error: Huge input lookup issue when parsing big XML files [hotfix]